### PR TITLE
Firefox send discontinued and replaced by `send`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ with compression and encryption.
 - [Archivy](https://archivy.github.io/) — knowledge repository that allows you to preserve content. [(GitHub)](https://github.com/archivy/archivy/)
 
 ### 🍕 Deploy your own `file sharing server`
-- [Firefox Send](https://github.com/mozilla/send) — simple, private file sharing with encryption.
 - [FilePizza](https://github.com/kern/filepizza) — peer-to-peer file transfers with only browser.
 - [Lufi](https://github.com/ldidry/lufi) — convenient file sharing with E2E encryption.
 - [Linx](https://github.com/andreimarcu/linx-server) — simple file/code/media sharing website.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ with compression and encryption.
 - [Archivy](https://archivy.github.io/) — knowledge repository that allows you to preserve content. [(GitHub)](https://github.com/archivy/archivy/)
 
 ### 🍕 Deploy your own `file sharing server`
+- [Send](https://gitlab.com/timvisee/send) — simple, private file sharing with encryption. A Firefox Send fork.
 - [FilePizza](https://github.com/kern/filepizza) — peer-to-peer file transfers with only browser.
 - [Lufi](https://github.com/ldidry/lufi) — convenient file sharing with E2E encryption.
 - [Linx](https://github.com/andreimarcu/linx-server) — simple file/code/media sharing website.


### PR DESCRIPTION
Firefox send was discontinued as of September 17th, 2020

https://support.mozilla.org/en-US/kb/what-happened-firefox-send