### PR TITLE
Add BunkerWeb to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ with compression and encryption.
 ### 🎙 Deploy your own `Twitch`
 - [Lightspeed](https://github.com/GRVYDEV/Project-Lightspeed) — a self-contained OBS → FTL → WebRTC live streaming server.
 
+### 🛡 Deploy your own `Web Application Firewall`
+- [BunkerWeb](https://www.bunkerweb.io) — A next-generation, open-source Web Application Firewall (WAF). [(GitHub)](https://github.com/bunkerity/bunkerweb)
+
 ### 🐳 Deploy your own `Container Management System`
 - [Portainer](https://www.portainer.io/) — container management tool. It allows anyone to deploy and manage containers without the need to write code. [(GitHub)](https://github.com/portainer/portainer)
 - [Yacht](https://github.com/SelfhostedPro/Yacht) — a web interface for managing docker containers with an emphasis on templating to provide 1 click deployments.


### PR DESCRIPTION
## Description
This PR adds [BunkerWeb](https://www.bunkerweb.io) to the `README.md` list.

## Changes
- Created a new category: `🛡 Deploy your own Web Application Firewall`
- Added **BunkerWeb**: an open-source Web Application Firewall (WAF) based on NGINX.

## Logic
BunkerWeb is a self-hosted WAF solution. As there was no existing category in the list that accurately described a firewall or security tool of this nature (neither "VPN", "AdBlock", nor "DNS" seemed appropriate), I created a new "Web Application Firewall" category to house it.
