### PR TITLE
Add Dakera: self-hosted AI agent memory service

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@
 | [MediaWiki](https://github.com/wikimedia/mediawiki) | Collaboration and documentation platform with enormous capabilities. | 5054 | 🟢 1h |
 | [Dokuwiki](https://github.com/splitbrain/dokuwiki) | Simple wiki that doesn't require a database. | 4612 | 🟢 22m |
 | [Hypothes.is](https://github.com/hypothesis/h) | Web annotating system with search, storing, collaboration, sharing and integrations. | 3138 | 🟢 4h |
+| [Dakera](https://github.com/dakera-ai/dakera) | Self-hosted AI agent memory service with hybrid semantic search and persistent storage. Deploy via Docker Compose with no cloud dependencies. | 0 | 🟢 0m |
 
 &nbsp;
 ### 🔑 Deploy your own `Password manager`


### PR DESCRIPTION
## Summary

Adds [Dakera](https://github.com/dakera-ai/dakera) to the "Information storing and organization system" section.

Dakera is a self-hosted AI agent memory service — deploy it yourself via Docker Compose to give LLM agents persistent, searchable memory with no cloud dependencies. Built in Rust, backed by RocksDB.

## Checklist

- [x] Follows existing table format (Name | Description | Stars | Updated)
- [x] No existing Dakera entry (verified with `grep -i dakera README.md`)
- [x] Placed in the most relevant section