### PR TITLE
Fix broken ONLYOFFICE Docker image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 | :--- | :--- | :---: | :--- |
 | [Nocodb](https://github.com/nocodb/nocodb) | Airtable alternative could be based on top of MySQL, PostgreSQL, SQL Server, SQLite & MariaDB with solid GUI | 63090 | 🟢 3m |
 | [Baserow](https://github.com/baserow/baserow) | Your own API-focused Airtable with plugins. | 4877 | 🟢 47m |
-| [ONLYOFFICE CE](https://github.com/ONLYOFFICE/DesktopEditors) | Private cloud office with collaboration features. CE version distributed as [Docker image](https://helpcenter.onlyoffice.com/server/docker/opensource/deploy-community-edition-in-digitalocean.aspx). | 4831 | 🟢 1d |
+| [ONLYOFFICE CE](https://github.com/ONLYOFFICE/DesktopEditors) | Private cloud office with collaboration features. CE version distributed as [Docker image](https://helpcenter.onlyoffice.com/server/docker/opensource/index.aspx). | 4831 | 🟢 1d |
 | [Collabora](https://github.com/CollaboraOnline/online) | LibreOffice in the cloud with collaboration features. | 3238 | 🟢 10h |
 | [SeaTable](https://github.com/seatable/seatable) | Your own Airtable where spreadsheets meets database. | 700 | 🟠 6mo |
 


### PR DESCRIPTION
The link to deploy-community-edition-in-digitalocean.aspx no longer serves its original content (now redirects to a Workspace-specific DigitalOcean install page). Replace with the canonical Docker installation index for the open-source edition, which better matches the surrounding description ("CE version distributed as Docker image").

Before: https://helpcenter.onlyoffice.com/server/docker/opensource/deploy-community-edition-in-digitalocean.aspx
After:  https://helpcenter.onlyoffice.com/server/docker/opensource/index.aspx